### PR TITLE
fix: can no longer format when JSON string is null

### DIFF
--- a/tools/json-formatter/src/components/JsonFormatter.vue
+++ b/tools/json-formatter/src/components/JsonFormatter.vue
@@ -28,6 +28,7 @@
 						class="JsonFormatter__toolbar__button"
 						v-text="'Format'"
 						size="sm"
+						:disabled="!jsonString"
 						@click.native="formatJSON"/>
 				</div>
 			</template>


### PR DESCRIPTION
Previously the text box would display `null` after pressing format when no text was entered. This disabled the `format` button if no `jsonString` is provided.