### PR TITLE
Feat: auto copy to clipboard

### DIFF
--- a/toolbox-layout/package-lock.json
+++ b/toolbox-layout/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "toolbox-layout",
-	"version": "0.1.12",
+	"version": "0.1.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/toolbox-layout/package.json
+++ b/toolbox-layout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "toolbox-layout",
-	"version": "0.1.12",
+	"version": "0.1.13",
 	"main": "./dist/toolbox-layout.common.js",
 	"scripts": {
 		"serve": "vue-cli-service serve",

--- a/toolbox-layout/src/components/ToolCode.vue
+++ b/toolbox-layout/src/components/ToolCode.vue
@@ -1,5 +1,7 @@
 <template>
 	<codemirror
+		ref="ToolCode"
+		:class="{ 'ToolCode--autoSize': autoSize }"
 		:value="value"
 		:options="optionsWithDefaults"
 		@input="onInput"/>
@@ -22,6 +24,10 @@ export default {
 		options: {
 			type: Object,
 			default: () => {}
+		},
+		autoSize: {
+			type: Boolean,
+			default: false
 		}
 	},
 	computed: {
@@ -33,12 +39,29 @@ export default {
 				...defaults,
 				...this.options
 			};
+		},
+		codemirror() {
+			return this.$refs.ToolCode.codemirror;
 		}
 	},
 	methods: {
 		onInput(data) {
 			this.$emit('input', data);
+		},
+		focus() {
+			this.codemirror.focus();
 		}
 	}
 };
 </script>
+
+<style lang="scss">
+.ToolCode {
+
+	&--autoSize {
+		.CodeMirror { // to allow the editor to grow with entered text
+			height: auto;
+		}
+	}
+}
+</style>

--- a/toolbox-layout/src/components/ToolCode.vue
+++ b/toolbox-layout/src/components/ToolCode.vue
@@ -35,6 +35,7 @@ export default {
 			const defaults = {
 				theme: 'cobalt'
 			};
+			if (this.autoSize) defaults.viewportMargin = Infinity;
 			return {
 				...defaults,
 				...this.options

--- a/toolbox-website/package-lock.json
+++ b/toolbox-website/package-lock.json
@@ -1424,9 +1424,9 @@
       }
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -3431,9 +3431,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.50.2.tgz",
-      "integrity": "sha512-PPjUsC1oXSM86lunKrw609P1oM0Wu8z9rqzjbeyBYCcx44VL41aUpccdOf1PfAZtTONlmN3sT3p2etLNYa1OGg=="
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.51.0.tgz",
+      "integrity": "sha512-vyuYYRv3eXL0SCuZA4spRFlKNzQAewHcipRQCOKgRy7VNAvZxTKzbItdbCl4S5AgPZ5g3WkHp+ibWQwv9TLG7Q=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -12530,9 +12530,9 @@
       "dev": true
     },
     "toolbox-layout": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/toolbox-layout/-/toolbox-layout-0.1.12.tgz",
-      "integrity": "sha512-oHooYhpqYjc3NEVh2pSSHUClFSVCk6k1gUUR3wwXPYurXFUuzI2e3cYwaeaQa1KCmOAn/OMNj6HE+gCcGXlZHg==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/toolbox-layout/-/toolbox-layout-0.1.13.tgz",
+      "integrity": "sha512-a+1Kq1KBB8E22a3Jjq6+vaNTPUH9DyqsrdkuFZ7qALv8HQWgKc3GP7N7pDrFsViIi/1TQ+Pb5MtwK7wvysHoDA==",
       "requires": {
         "@vue/eslint-config-airbnb": "^5.0.2",
         "bootstrap": "^4.4.1",

--- a/toolbox-website/package.json
+++ b/toolbox-website/package.json
@@ -11,7 +11,7 @@
 		"bootstrap": "^4.4.1",
 		"bootstrap-vue": "^2.2.2",
 		"core-js": "^3.4.4",
-		"toolbox-layout": "^0.1.12",
+		"toolbox-layout": "^0.1.13",
 		"vue": "^2.6.11",
 		"vue-router": "^3.1.3"
 	},

--- a/tools/json-formatter/package-lock.json
+++ b/tools/json-formatter/package-lock.json
@@ -1349,9 +1349,9 @@
 			}
 		},
 		"@types/long": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -1796,6 +1796,17 @@
 					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				}
+			}
+		},
+		"@vue/eslint-config-airbnb": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@vue/eslint-config-airbnb/-/eslint-config-airbnb-5.0.2.tgz",
+			"integrity": "sha512-9wD5OfdkQ0TDYLRynP46AxOHck866zkvZoT8MgjyJNBPegTtrsIQ3cu10ZF4Nl/aU5qKeSOaY58D4YXPqF0NZg==",
+			"requires": {
+				"eslint-config-airbnb-base": "^14.0.0",
+				"eslint-import-resolver-node": "^0.3.3",
+				"eslint-import-resolver-webpack": "^0.11.1",
+				"eslint-plugin-import": "^2.18.2"
 			}
 		},
 		"@vue/preload-webpack-plugin": {
@@ -3345,9 +3356,9 @@
 			"dev": true
 		},
 		"codemirror": {
-			"version": "5.50.2",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.50.2.tgz",
-			"integrity": "sha512-PPjUsC1oXSM86lunKrw609P1oM0Wu8z9rqzjbeyBYCcx44VL41aUpccdOf1PfAZtTONlmN3sT3p2etLNYa1OGg=="
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.51.0.tgz",
+			"integrity": "sha512-vyuYYRv3eXL0SCuZA4spRFlKNzQAewHcipRQCOKgRy7VNAvZxTKzbItdbCl4S5AgPZ5g3WkHp+ibWQwv9TLG7Q=="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -4705,7 +4716,6 @@
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
 			"integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
-			"dev": true,
 			"requires": {
 				"confusing-browser-globals": "^1.0.7",
 				"object.assign": "^4.1.0",
@@ -12384,9 +12394,9 @@
 			"dev": true
 		},
 		"toolbox-layout": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/toolbox-layout/-/toolbox-layout-0.1.12.tgz",
-			"integrity": "sha512-oHooYhpqYjc3NEVh2pSSHUClFSVCk6k1gUUR3wwXPYurXFUuzI2e3cYwaeaQa1KCmOAn/OMNj6HE+gCcGXlZHg==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/toolbox-layout/-/toolbox-layout-0.1.13.tgz",
+			"integrity": "sha512-a+1Kq1KBB8E22a3Jjq6+vaNTPUH9DyqsrdkuFZ7qALv8HQWgKc3GP7N7pDrFsViIi/1TQ+Pb5MtwK7wvysHoDA==",
 			"requires": {
 				"@vue/eslint-config-airbnb": "^5.0.2",
 				"bootstrap": "^4.4.1",
@@ -12397,29 +12407,6 @@
 				"marked": "^0.8.0",
 				"vue": "^2.6.11",
 				"vue-codemirror": "^4.0.6"
-			},
-			"dependencies": {
-				"@vue/eslint-config-airbnb": {
-					"version": "5.0.2",
-					"resolved": "https://registry.npmjs.org/@vue/eslint-config-airbnb/-/eslint-config-airbnb-5.0.2.tgz",
-					"integrity": "sha512-9wD5OfdkQ0TDYLRynP46AxOHck866zkvZoT8MgjyJNBPegTtrsIQ3cu10ZF4Nl/aU5qKeSOaY58D4YXPqF0NZg==",
-					"requires": {
-						"eslint-config-airbnb-base": "^14.0.0",
-						"eslint-import-resolver-node": "^0.3.3",
-						"eslint-import-resolver-webpack": "^0.11.1",
-						"eslint-plugin-import": "^2.18.2"
-					}
-				},
-				"eslint-config-airbnb-base": {
-					"version": "14.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
-					"integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
-					"requires": {
-						"confusing-browser-globals": "^1.0.7",
-						"object.assign": "^4.1.0",
-						"object.entries": "^1.1.0"
-					}
-				}
 			}
 		},
 		"toposort": {

--- a/tools/json-formatter/package.json
+++ b/tools/json-formatter/package.json
@@ -11,7 +11,7 @@
 		"bootstrap": "^4.4.1",
 		"bootstrap-vue": "^2.2.1",
 		"core-js": "^3.4.4",
-		"toolbox-layout": "^0.1.12",
+		"toolbox-layout": "^0.1.13",
 		"v-clipboard": "^2.2.2",
 		"vue": "^2.6.11"
 	},

--- a/tools/json-formatter/src/JsonFormatter.vue
+++ b/tools/json-formatter/src/JsonFormatter.vue
@@ -11,6 +11,7 @@ Enter your [JSON](https://www.json.org) below to get started:
 			:message="errorMessage"/>
 
 		<tool-code
+			ref="JsonFormatter__input"
 			class="JsonFormatter__input"
 			v-model="jsonString"
 			:options="codeOptions"/>
@@ -95,6 +96,7 @@ export default {
 			this.formatted = false;
 			this.errorMessage = null;
 			this.jsonString = '';
+			this.$refs.JsonFormatter__input.focus();
 		}
 	}
 };

--- a/tools/json-formatter/src/JsonFormatter.vue
+++ b/tools/json-formatter/src/JsonFormatter.vue
@@ -14,7 +14,8 @@ Enter your [JSON](https://www.json.org) below to get started:
 			ref="JsonFormatter__input"
 			class="JsonFormatter__input"
 			v-model="jsonString"
-			:options="codeOptions"/>
+			:options="codeOptions"
+			:autoSize="true"/>
 
 		<tool-taskbar v-if="jsonString">
 

--- a/tools/json-formatter/src/JsonFormatter.vue
+++ b/tools/json-formatter/src/JsonFormatter.vue
@@ -100,7 +100,7 @@ export default {
 		}
 	},
 	mounted() {
-		this.$refs.MarkdownRenderer__input.focus();
+		this.$refs.JsonFormatter__input.focus();
 	}
 };
 </script>

--- a/tools/json-formatter/src/JsonFormatter.vue
+++ b/tools/json-formatter/src/JsonFormatter.vue
@@ -71,6 +71,7 @@ export default {
 			return {
 				readOnly: !!this.formatted,
 				lineNumbers: true,
+				autoFocus: true,
 				mode: 'JSON'
 			};
 		}

--- a/tools/json-formatter/src/JsonFormatter.vue
+++ b/tools/json-formatter/src/JsonFormatter.vue
@@ -71,8 +71,7 @@ export default {
 			return {
 				readOnly: !!this.formatted,
 				lineNumbers: true,
-				mode: 'JSON',
-				viewportMargin: Infinity // to allow the editor to grow with entered text
+				mode: 'JSON'
 			};
 		}
 	},
@@ -115,10 +114,6 @@ export default {
 
 	&__input {
 		margin-bottom: 150px; // to allow for the taskbar
-
-		.CodeMirror { // to allow the editor to grow with entered text
-			height: auto;
-		}
 	}
 
 	&__button {

--- a/tools/json-formatter/src/JsonFormatter.vue
+++ b/tools/json-formatter/src/JsonFormatter.vue
@@ -73,7 +73,6 @@ export default {
 			return {
 				readOnly: !!this.formatted,
 				lineNumbers: true,
-				autoFocus: true,
 				mode: 'JSON'
 			};
 		}
@@ -99,6 +98,9 @@ export default {
 			this.jsonString = '';
 			this.$refs.JsonFormatter__input.focus();
 		}
+	},
+	mounted() {
+		this.$refs.MarkdownRenderer__input.focus();
 	}
 };
 </script>

--- a/tools/markdown-renderer/package-lock.json
+++ b/tools/markdown-renderer/package-lock.json
@@ -12498,9 +12498,9 @@
 			"dev": true
 		},
 		"toolbox-layout": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/toolbox-layout/-/toolbox-layout-0.1.12.tgz",
-			"integrity": "sha512-oHooYhpqYjc3NEVh2pSSHUClFSVCk6k1gUUR3wwXPYurXFUuzI2e3cYwaeaQa1KCmOAn/OMNj6HE+gCcGXlZHg==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/toolbox-layout/-/toolbox-layout-0.1.13.tgz",
+			"integrity": "sha512-a+1Kq1KBB8E22a3Jjq6+vaNTPUH9DyqsrdkuFZ7qALv8HQWgKc3GP7N7pDrFsViIi/1TQ+Pb5MtwK7wvysHoDA==",
 			"requires": {
 				"@vue/eslint-config-airbnb": "^5.0.2",
 				"bootstrap": "^4.4.1",

--- a/tools/markdown-renderer/package.json
+++ b/tools/markdown-renderer/package.json
@@ -11,7 +11,7 @@
 		"bootstrap": "^4.4.1",
 		"bootstrap-vue": "^2.2.1",
 		"core-js": "^3.4.4",
-		"toolbox-layout": "^0.1.11",
+		"toolbox-layout": "^0.1.13",
 		"v-clipboard": "^2.2.2",
 		"vue": "^2.6.11"
 	},

--- a/tools/markdown-renderer/src/MarkdownRenderer.vue
+++ b/tools/markdown-renderer/src/MarkdownRenderer.vue
@@ -3,16 +3,30 @@
 
 		<section class="MarkdownRenderer__header">
 			<p>Enter your markdown below:</p>
-			<tool-button
-				v-text="'Copy to Clipboard'"
-				@click.native="onCopyClick"/>
+
+			<div class="MarkdownRenderer__header__buttons">
+				<tool-button
+					v-if="!autoCopy"
+					class="MarkdownRenderer__header__button"
+					v-text="'Copy to Clipboard'"
+					@click.native="onCopyClick"/>
+
+				<b-form-checkbox
+					name="MarkdownRenderer__autoCopy"
+					v-model="autoCopy"
+					switch>
+					Auto Copy to Clipboard
+				</b-form-checkbox>
+			</div>
 		</section>
 
 		<section class="MarkdownRenderer__content">
 			<tool-code
-				class="MarkdownRenderer__editor MarkdownRenderer__content__item MarkdownRenderer__content__item--left"
+				ref="MarkdownRenderer__input"
+				class="MarkdownRenderer__content__item MarkdownRenderer__content__item--left"
 				v-model="markdown"
-				:options="codeOptions"/>
+				:options="codeOptions"
+				:autoSize="true"/>
 
 			<tool-markdown
 				class="MarkdownRenderer__content__item MarkdownRenderer__content__item--right"
@@ -29,14 +43,24 @@ export default {
 			markdown: '',
 			codeOptions: {
 				mode: 'Markdown',
-				viewportMargin: Infinity
-			}
+				autoFocus: true
+			},
+			autoCopy: false
 		};
 	},
 	methods: {
 		onCopyClick() {
 			this.$clipboard(this.markdown);
 		}
+	},
+	watch: {
+		markdown() {
+			this.$clipboard(this.markdown);
+			this.$refs.MarkdownRenderer__input.focus();
+		}
+	},
+	mounted() {
+		this.$refs.MarkdownRenderer__input.focus();
 	}
 };
 </script>
@@ -54,6 +78,15 @@ export default {
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
+
+		&__buttons {
+			display: flex;
+			flex-direction: row;
+		}
+
+		&__button {
+			margin-right: 1rem;
+		}
 	}
 
 	&__content {
@@ -70,12 +103,6 @@ export default {
 			&--right {
 				margin-left: 1rem;
 			}
-		}
-	}
-
-	&__editor {
-		.CodeMirror { // to allow the editor to grow with entered text
-			height: auto;
 		}
 	}
 }

--- a/tools/markdown-renderer/src/MarkdownRenderer.vue
+++ b/tools/markdown-renderer/src/MarkdownRenderer.vue
@@ -42,8 +42,7 @@ export default {
 		return {
 			markdown: '',
 			codeOptions: {
-				mode: 'Markdown',
-				autoFocus: true
+				mode: 'Markdown'
 			},
 			autoCopy: false
 		};


### PR DESCRIPTION
This PR adds a toggle switch to the Markdown Renderer tool. When active it automatically copies any text entered to the clipboard whenever it is modified.

## Changes
- **[feat]:** markdown-renderer has option to auto copy to clipboard
- **[feat]:** toolbox-layout's ToolCode now has the `focus()` method
- **[feat]:** json-formatter now auto focuses the input when loaded and when reset clicked
- **[feat]:** markdown-renderer now auto focuses the input when loaded 
- **[chore]:** toolbox-layout's `autoSize` prop now provides autoSize functionality instead of coded in each tool