### PR TITLE
chore: add reference to SEO performance to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ See [`.project/processes/creating-new-tool.md`](.project/processes/creating-new-
 
 ### Roadmap
 - Add a menu to the tools layout linking to other tools (when we have them)
-- add CI tooling to automate the deployment of sections on merge into master
+- Improve mobile usability of each of our tools and our main website

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The Vue component library behind these UIs can be found at [`toolbox-layout`](/t
 ### Automation
 We have some automated workflows that run in this repo. They can be found in [`.github/workflows`](/.github/workflows).
 
+## Analytics and SEO
+- SEO performance can be seen here: https://search.google.com/search-console?resource_id=sc-domain%3Aholistic-toolbox.com
+
 ## Contributing
 Contributions are very welcome, just raise an issue / open a pull request!
 


### PR DESCRIPTION
As part of https://github.com/holistic-web/holistic-toolbox/issues/34.

Adds a reference to google's SEO tool to our main README, and adds a mobile friendly improvement to our roadmap.