### PR TITLE
feat: add browse json link to json-formatter

### DIFF
--- a/tools/json-formatter/README.md
+++ b/tools/json-formatter/README.md
@@ -6,6 +6,10 @@ The JSON rendering is done with the built in [`JSON.stringify(...)`](https://dev
 
 Hosted at https://json-formatter.holistic-toolbox.com
 
+## Functionality
+Along with JSON formatting, this tool supports:
+- browsing the formatted JSON with a link to json-formatter
+
 ## Development
 To develop for this project:
 1. Install dependencies

--- a/tools/json-formatter/src/JsonFormatter.vue
+++ b/tools/json-formatter/src/JsonFormatter.vue
@@ -42,6 +42,12 @@ Enter your [JSON](https://www.json.org) below to get started:
 					v-text="'Copy Output'"
 					v-clipboard="jsonString"/>
 				<tool-button
+					size="lg"
+					class="JsonFormatter__button"
+					v-text="'Browse JSON'"
+					:href="`https://json-formatter.holistic-toolbox.com?JSON=${jsonString}`"
+					target="_blank"/>
+				<tool-button
 					size="sm"
 					class="JsonFormatter__button"
 					variant="secondary"


### PR DESCRIPTION
To address #39

- [x]  **#65 must be merged before this**, as it relies on functionality included in that PR

## Changes
- **[feat]** add link to browse formatted JSON using json-formatter